### PR TITLE
chore: optimize base64 encoding for wasm file

### DIFF
--- a/node/src/build_index.sh
+++ b/node/src/build_index.sh
@@ -27,12 +27,14 @@ truncate_js_file() {
 append_base64_wasm_to_js() {
     local wasm_file=$1
     local js_file=$2
-    if ! base64 "$wasm_file" > /dev/null 2>&1; then
+
+    local base64_wasm
+    if ! base64_wasm=$(base64 "$wasm_file"); then
         echo "Error: Failed to Base64-encode the WASM file."
         return 1
     fi
-    local base64_wasm=$(base64 "$wasm_file")
-    echo -e "\n// Embedded WASM (Base64 Encoded)" >> "$js_file"
+    
+    printf "\n// Embedded WASM (Base64 Encoded)\n" >> "$js_file"
     echo "let wasmCode = \`$base64_wasm\`;" >> "$js_file"
     echo "const wasmBytes = Uint8Array.from(atob(wasmCode), c => c.charCodeAt(0));" >> "$js_file"
 }


### PR DESCRIPTION
# What changes are included in this PR?

`base64 "$wasm_file"` was being called twice: once for checking the file and another for extracting the data. this led to unnecessary work, especially for large files, and could also result in inconsistent behavior if the file changes between the calls.

**changes**

- removed the redundant check `base64 "$wasm_file" > /dev/null` as it’s no longer needed.
- replaced `echo -e` with `printf` to avoid potential issues with the `-e` flag.
- now, `base64_wasm` is called just once and the result is stored in a variable.

# Are these changes tested?

yes, the changes were tested by running the script with a sample wasm file to ensure that the encoding behavior is consistent and that performance is improved with larger files.