### PR TITLE
fix: return type of wasm verify_prover_response_dory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,6 +4504,7 @@ dependencies = [
  "bincode",
  "gloo-utils",
  "hex",
+ "indexmap 2.6.0",
  "lazy_static",
  "parity-scale-codec",
  "proof-of-sql",

--- a/crates/proof-of-sql-sdk-wasm/Cargo.toml
+++ b/crates/proof-of-sql-sdk-wasm/Cargo.toml
@@ -13,6 +13,7 @@ ark-serialize = { workspace = true }
 bincode = { workspace = true, default-features = false, features = ["serde"] }
 gloo-utils = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
+indexmap = { workspace = true }
 lazy_static = { workspace = true }
 parity-scale-codec = { workspace = true, features = ["derive"] }
 proof-of-sql = { workspace = true }

--- a/examples/chainlink/source.js
+++ b/examples/chainlink/source.js
@@ -20,8 +20,8 @@ const result = await client.queryAndVerify(
 );
 
 // Extract the results from the response
-let t_count = result.table.t_count.Int[0];
-let b_count = result.table.b_count.BigInt[0];
+let t_count = result.t_count.Int[0];
+let b_count = result.b_count.BigInt[0];
 
 console.log("Average eth transactions per block: ");
 return Functions.encodeUint256(Math.floor(t_count / b_count));

--- a/examples/deno/query.js
+++ b/examples/deno/query.js
@@ -21,8 +21,8 @@ try {
         table
     );
 
-    let t_count = result.table.t_count.Int[0];
-    let b_count = result.table.b_count.BigInt[0];
+    let t_count = result.t_count.Int[0];
+    let b_count = result.b_count.BigInt[0];
     console.log("Average eth transactions per block: ", t_count / b_count);
 
     console.log("Workflow completed successfully:", result);

--- a/examples/node/query.js
+++ b/examples/node/query.js
@@ -20,8 +20,8 @@ try {
         table
     );
 
-    let t_count = result.table.t_count.Int[0];
-    let b_count = result.table.b_count.BigInt[0];
+    let t_count = result.t_count.Int[0];
+    let b_count = result.b_count.BigInt[0];
     console.log("Average eth transactions per block: ", t_count / b_count);
 
     console.log("Workflow completed successfully:", result);


### PR DESCRIPTION
# Rationale for this change

The return type of `verify_prover_response_dory`, (`OwnedTable`), is not working with `JsValue::from_serde`, because there is a dictionary key that is not a string. This handles that problem.

# What changes are included in this PR?

Returning a dictionary type rather than an `OwnedTable` type from `verify_prover_response_dory`.

# Are these changes tested?
Not really.
