### PR TITLE
fix: remove timeout from post http request

### DIFF
--- a/node/src/index_tail.js
+++ b/node/src/index_tail.js
@@ -106,13 +106,11 @@ export class SxTClient {
 
 async function postHttpRequest({ url, headers = {}, data = null }) {
   const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), 3000);
   const response = await fetch(url, {
     method: "POST",
     headers,
     body: data ? JSON.stringify(data) : undefined,
     signal: controller.signal,
   });
-  clearTimeout(id);
   return response;
 }


### PR DESCRIPTION
# Rationale for this change

The way the logic is currently written, any http request that takes longer than 3 seconds will be aborted. This is not desirable, for obvious reasons.

# What changes are included in this PR?

Removal of the timeout

# Are these changes tested?
Kind of. There's examples that use this code.
