### PR TITLE
feat!: upgrade proof of sql to 0.114.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom 0.2.15",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -943,19 +943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake3"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.6",
- "cc",
- "cfg-if",
- "constant_time_eq 0.3.1",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,7 +1219,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "once_cell",
  "tiny-keccak",
 ]
@@ -2311,20 +2298,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3430,7 +3405,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -3993,9 +3968,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql"
-version = "0.99.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a23aaf9a246b07baefa3f111b01fb15c94713bb7a2d15f706c2bb4ee5d29ca"
+checksum = "99b2fee7691ac9f58b64cb49509ce22765aae7af98941789b24d74635d265841"
 dependencies = [
  "ahash",
  "ark-bls12-381",
@@ -4010,7 +3985,6 @@ dependencies = [
  "bigdecimal",
  "bincode",
  "bit-iter",
- "blake3",
  "bnum",
  "bumpalo",
  "byte-slice-cast",
@@ -4037,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql-parser"
-version = "0.99.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2781752cd7a059e4cea0fe05910a300bcb7ce1eed9a2de0aec8fda2c065d57d"
+checksum = "8b375c5a9cf5ecc0b3b1538049bc6aa3df5f779859480c8978e57e9dd4f412df"
 dependencies = [
  "arrayvec 0.7.6",
  "bigdecimal",
@@ -4053,14 +4027,14 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql-planner"
-version = "0.99.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f01f2f55e6a76223b9053399798d5a15dad6875572cab7b7a0a538a44ce47a"
+checksum = "ff5fc0cb214645845e4c37f1da6d61fc0d3aede712f36355faecb3e10d4cb8d5"
 dependencies = [
  "ahash",
  "arrow",
  "datafusion",
- "getrandom 0.2.15",
+ "getrandom",
  "indexmap 2.9.0",
  "proof-of-sql",
  "serde",
@@ -4132,12 +4106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4170,7 +4138,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
 ]
 
 [[package]]
@@ -4309,7 +4277,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom",
  "libc",
  "spin",
  "untrusted",
@@ -5248,7 +5216,7 @@ dependencies = [
  "either",
  "frame-metadata 16.0.0",
  "futures",
- "getrandom 0.2.15",
+ "getrandom",
  "hex",
  "impl-serde",
  "instant",
@@ -5281,7 +5249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d703dca0905cc5272d7cc27a4ac5f37dcaae7671acc7fef0200057cc8c317786"
 dependencies = [
  "frame-metadata 16.0.0",
- "getrandom 0.2.15",
+ "getrandom",
  "heck 0.5.0",
  "hex",
  "jsonrpsee 0.22.5",
@@ -5332,7 +5300,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "futures-util",
- "getrandom 0.2.15",
+ "getrandom",
  "instant",
  "js-sys",
  "pin-project",
@@ -5936,12 +5904,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom 0.3.2",
- "js-sys",
+ "getrandom",
  "wasm-bindgen",
 ]
 
@@ -5981,15 +5948,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -6320,15 +6278,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ lazy_static = { version = "1.5.0" }
 log = "0.4.22"
 indexmap = "2.8.0"
 parity-scale-codec = { version = "3.7.0", default-features = false }
-proof-of-sql = { version = "0.99.0", default-features = false }
-proof-of-sql-planner = { version = "0.99.0", default-features = false }
+proof-of-sql = { version = "0.114.0", default-features = false }
+proof-of-sql-planner = { version = "0.114.0", default-features = false }
 prost = "0.12"
 prost-build = "0.12"
 prost-types = "0.12"


### PR DESCRIPTION
# Rationale for this change

We need to upgrade proof of sql across the board for testing the new group by functionality in solidity.

# What changes are included in this PR?

Upgrade of proof of sql

# Are these changes tested?
Yes
