### PR TITLE
feat: add `CommitmentScheme` and add conversions 

### DIFF
--- a/crates/proof-of-sql-sdk-local/src/commitment_scheme.rs
+++ b/crates/proof-of-sql-sdk-local/src/commitment_scheme.rs
@@ -1,4 +1,6 @@
-use crate::prover::CommitmentScheme;
+use crate::{
+    prover, sxt_chain_runtime::api::runtime_types::proof_of_sql_commitment_map::commitment_scheme,
+};
 use proof_of_sql::{
     base::commitment::CommitmentEvaluationProof,
     proof_primitive::{
@@ -6,6 +8,35 @@ use proof_of_sql::{
     },
 };
 use serde::{Deserialize, Serialize};
+
+/// Commitment schemes used in the proof-of-sql SDK.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommitmentScheme {
+    /// Dynamic Dory commitment scheme.
+    DynamicDory,
+    /// Hyper KZG commitment scheme.
+    HyperKzg,
+}
+
+/// Convert a `CommitmentScheme` to a `prover::CommitmentScheme`.
+impl From<CommitmentScheme> for prover::CommitmentScheme {
+    fn from(scheme: CommitmentScheme) -> Self {
+        match scheme {
+            CommitmentScheme::DynamicDory => Self::DynamicDory,
+            CommitmentScheme::HyperKzg => Self::HyperKzg,
+        }
+    }
+}
+
+/// Convert a `CommitmentScheme` to a `commitment_scheme::CommitmentScheme`.
+impl From<CommitmentScheme> for commitment_scheme::CommitmentScheme {
+    fn from(scheme: CommitmentScheme) -> Self {
+        match scheme {
+            CommitmentScheme::DynamicDory => Self::DynamicDory,
+            CommitmentScheme::HyperKzg => Self::HyperKzg,
+        }
+    }
+}
 
 /// Trait for commitment evaluation proofs that defines their associated [`CommitmentScheme`].
 pub trait CommitmentEvaluationProofId:

--- a/crates/proof-of-sql-sdk-local/src/lib.rs
+++ b/crates/proof-of-sql-sdk-local/src/lib.rs
@@ -5,7 +5,7 @@ mod duration_serde;
 pub mod sxt_chain_runtime;
 
 mod commitment_scheme;
-pub use commitment_scheme::CommitmentEvaluationProofId;
+pub use commitment_scheme::{CommitmentEvaluationProofId, CommitmentScheme};
 
 mod substrate_query;
 pub use substrate_query::table_ref_to_table_id;

--- a/crates/proof-of-sql-sdk-local/src/prover_query.rs
+++ b/crates/proof-of-sql-sdk-local/src/prover_query.rs
@@ -1,5 +1,5 @@
 use crate::{
-    prover::{ProverContextRange, ProverQuery},
+    prover::{self, ProverContextRange, ProverQuery},
     uppercase_accessor::UppercaseAccessor,
     CommitmentEvaluationProofId,
 };
@@ -85,7 +85,7 @@ pub fn plan_prover_query<CPI: CommitmentEvaluationProofId>(
         ProverQuery {
             proof_plan: serialized_proof_plan,
             query_context,
-            commitment_scheme: CPI::COMMITMENT_SCHEME.into(),
+            commitment_scheme: prover::CommitmentScheme::from(CPI::COMMITMENT_SCHEME).into(),
         },
         proof_plan_with_postprocessing,
     ))


### PR DESCRIPTION
# Rationale for this change
This fixes the NIT in #89. It is better to have our own SDK definition of `CommitmentScheme` and provide conversion to prover `CommitmentScheme` and chain `CommitmentScheme`.
# Details of this change
- define `CommitmentScheme` for the SDK
- impl `From<CommitmentScheme>` for `prover::CommitmentScheme` and `commitment_scheme::CommitmentScheme`