### PR TITLE
fix: add hyperkzg feature to local crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4.22"
 indexmap = "2.8.0"
 nova-snark = { version = "0.41.0", default-features = false }
 parity-scale-codec = { version = "3.7.0", default-features = false }
-proof-of-sql = { version = "0.114.0", default-features = false, features = ["hyperkzg_proof"] }
+proof-of-sql = { version = "0.114.0", default-features = false }
 proof-of-sql-planner = { version = "0.114.0", default-features = false }
 prost = "0.12"
 prost-build = "0.12"

--- a/crates/proof-of-sql-sdk-local/Cargo.toml
+++ b/crates/proof-of-sql-sdk-local/Cargo.toml
@@ -11,7 +11,7 @@ bincode = { workspace = true, default-features = false, features = ["serde", "al
 bumpalo = { workspace = true }
 clap = { workspace = true }
 datafusion = { workspace = true }
-nova-snark = { workspace = true, default-features = false }
+nova-snark = { workspace = true, default-features = false, optional = true }
 proof-of-sql = { workspace = true }
 proof-of-sql-planner = { workspace = true }
 prost = { workspace = true }
@@ -38,3 +38,4 @@ default = ["native", "prover-client"]
 prover-client = ["tonic/transport"]
 native = ["subxt/native"]
 web = ["subxt/web"]
+hyperkzg = ["proof-of-sql/hyperkzg_proof", "nova-snark"]

--- a/crates/proof-of-sql-sdk-local/src/commitment_scheme.rs
+++ b/crates/proof-of-sql-sdk-local/src/commitment_scheme.rs
@@ -4,13 +4,13 @@ use crate::{
 use ark_serialize::{CanonicalDeserialize, Compress, Validate};
 use bumpalo::Bump;
 use clap::ValueEnum;
+#[cfg(feature = "hyperkzg")]
 use nova_snark::provider::hyperkzg::VerifierKey;
+#[cfg(feature = "hyperkzg")]
+use proof_of_sql::proof_primitive::hyperkzg::{HyperKZGCommitmentEvaluationProof, HyperKZGEngine};
 use proof_of_sql::{
     base::commitment::CommitmentEvaluationProof,
-    proof_primitive::{
-        dory::{DynamicDoryEvaluationProof, VerifierSetup},
-        hyperkzg::{HyperKZGCommitmentEvaluationProof, HyperKZGEngine},
-    },
+    proof_primitive::dory::{DynamicDoryEvaluationProof, VerifierSetup},
 };
 use serde::{Deserialize, Serialize};
 
@@ -20,6 +20,7 @@ pub enum CommitmentScheme {
     /// Dynamic Dory commitment scheme.
     DynamicDory,
     /// Hyper KZG commitment scheme.
+    #[cfg(feature = "hyperkzg")]
     HyperKzg,
 }
 
@@ -28,6 +29,7 @@ impl From<CommitmentScheme> for prover::CommitmentScheme {
     fn from(scheme: CommitmentScheme) -> Self {
         match scheme {
             CommitmentScheme::DynamicDory => Self::DynamicDory,
+            #[cfg(feature = "hyperkzg")]
             CommitmentScheme::HyperKzg => Self::HyperKzg,
         }
     }
@@ -38,6 +40,7 @@ impl From<CommitmentScheme> for commitment_scheme::CommitmentScheme {
     fn from(scheme: CommitmentScheme) -> Self {
         match scheme {
             CommitmentScheme::DynamicDory => Self::DynamicDory,
+            #[cfg(feature = "hyperkzg")]
             CommitmentScheme::HyperKzg => Self::HyperKzg,
         }
     }
@@ -63,6 +66,7 @@ pub trait CommitmentEvaluationProofId:
     >;
 }
 
+#[cfg(feature = "hyperkzg")]
 impl CommitmentEvaluationProofId for HyperKZGCommitmentEvaluationProof {
     const COMMITMENT_SCHEME: CommitmentScheme = CommitmentScheme::HyperKzg;
     type DeserializationError = bincode::error::DecodeError;

--- a/crates/proof-of-sql-sdk-local/src/lib.rs
+++ b/crates/proof-of-sql-sdk-local/src/lib.rs
@@ -17,9 +17,10 @@ mod uppercase_accessor;
 pub use uppercase_accessor::uppercase_table_ref;
 
 mod prover_query;
+#[cfg(feature = "hyperkzg")]
+pub use prover_query::plan_prover_query_hyperkzg;
 pub use prover_query::{
-    plan_prover_query, plan_prover_query_dory, plan_prover_query_hyperkzg, PlanProverQueryError,
-    DEFAULT_SCHEMA,
+    plan_prover_query, plan_prover_query_dory, PlanProverQueryError, DEFAULT_SCHEMA,
 };
 
 mod verify;

--- a/crates/proof-of-sql-sdk-local/src/prover_query.rs
+++ b/crates/proof-of-sql-sdk-local/src/prover_query.rs
@@ -4,12 +4,13 @@ use crate::{
     CommitmentEvaluationProofId,
 };
 use datafusion::config::ConfigOptions;
+#[cfg(feature = "hyperkzg")]
+use proof_of_sql::proof_primitive::hyperkzg::{
+    HyperKZGCommitment, HyperKZGCommitmentEvaluationProof,
+};
 use proof_of_sql::{
     base::commitment::{CommitmentEvaluationProof, QueryCommitments},
-    proof_primitive::{
-        dory::{DynamicDoryCommitment, DynamicDoryEvaluationProof},
-        hyperkzg::{HyperKZGCommitment, HyperKZGCommitmentEvaluationProof},
-    },
+    proof_primitive::dory::{DynamicDoryCommitment, DynamicDoryEvaluationProof},
     sql::parse::ConversionError,
 };
 use proof_of_sql_planner::{
@@ -100,6 +101,7 @@ pub fn plan_prover_query_dory(
 }
 
 /// Create a query for the prover service from sql query text and HyperKZG commitments.
+#[cfg(feature = "hyperkzg")]
 pub fn plan_prover_query_hyperkzg(
     query: &Statement,
     commitments: &QueryCommitments<HyperKZGCommitment>,

--- a/crates/proof-of-sql-sdk/Cargo.toml
+++ b/crates/proof-of-sql-sdk/Cargo.toml
@@ -21,7 +21,7 @@ reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 sqlparser = { workspace = true, features = ["visitor", "std"] }
 subxt = { workspace = true, features = ["jsonrpsee"] }
-sxt-proof-of-sql-sdk-local = { workspace = true, features = ["native", "prover-client"] }
+sxt-proof-of-sql-sdk-local = { workspace = true, features = ["hyperkzg", "native", "prover-client"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 snafu = { workspace = true }
 itertools = { workspace = true }


### PR DESCRIPTION
# Rationale for this change
HyperKZG is currently not WASM-compatible hence we need to put it behind a feature flag in the `sxt-proof-of-sql-sdk-local` crate and enable it in the `sxt-proof-of-sql-sdk` crate so that it will be available but not in `sxt-proof-of-sql-sdk-wasm`.