### PR TITLE
ci: publish crates to `cargo`

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,0 +1,40 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read # for checkout
+jobs:
+  lint-and-test:
+    uses: ./.github/workflows/lint-and-test.yml
+
+  release:
+    name: Release
+    runs-on: large-8-core-32gb-22-04
+    needs: [lint-and-test]
+    environment: deploy #!! DO NOT CHANGE THIS LINE !! #
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
+    steps:
+      - uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 0 # download tags, see https://github.com/actions/checkout/issues/100
+      - run: git config --global --add safe.directory $(realpath .)
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20.x"
+      - name: Install cargo info
+        run: |
+          cargo install cargo-info
+      - name: Semantic Release
+        run: |
+          npm install semantic-release
+          npx semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !examples/node/package.json
 !examples/chainlink/package.json
 !examples/chainlink/abi/functionsClient.json
+!package.json
 
 # Ignore .env.enc files anywhere in the repo
 **/.env.enc

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -Eeuxo pipefail
+
+# number to be used to tag the compressed files
+NEW_VERSION=$1
+
+if ! [[ ${NEW_VERSION} =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]
+then
+    echo "Incorrect version format: " $NEW_VERSION
+    exit 1
+fi
+
+# configure rust lib to release
+sed -i 's/version = "*.*.*" # DO NOT CHANGE THIS LINE! This will be automatically updated/version = "'${NEW_VERSION}'"/' Cargo.toml
+sed -i 's/path = "[^"]*"/version = "'${NEW_VERSION}'"/g' Cargo.toml
+
+CRATES=("proof-of-sql-sdk-cli")
+
+for crate in "${CRATES[@]}"; do
+  echo "Attempting to see if ${crate}@${NEW_VERSION} is published already..." 
+  # Make sure to use the correct index URL for crates.io since local crates are otherwise considered
+  # which will always succeed and nothing will be published
+  if cargo info --index https://github.com/rust-lang/crates.io-index \
+     "${crate}@${NEW_VERSION}" >/dev/null 2>&1
+  then
+    echo "The version ${NEW_VERSION} for ${crate} is already on crates.io. Skipping publish."
+  else
+    echo "${crate}@${NEW_VERSION} not found, publishing..."
+    cargo publish -p "${crate}" --token "${CRATES_TOKEN}" --allow-dirty
+  fi
+done

--- a/package.json
+++ b/package.json
@@ -1,0 +1,56 @@
+{
+    "name": "proof_of_sql_sdk",
+    "version": "0.0.0-development",
+    "devDependencies": {
+        "conventional-changelog-conventionalcommits": "^5.0.0",
+        "semantic-release": "^21.0.5"
+    },
+    "release": {
+        "branches": [
+            "main"
+        ],
+        "tagFormat": "v${version}",
+        "plugins": [
+            [
+                "@semantic-release/commit-analyzer",
+                {
+                    "preset": "conventionalCommits",
+                    "releaseRules": [
+                        { "breaking": true, "release": "minor" },
+                        { "revert": true, "release": "patch" },
+                        { "type": "feat", "release": "patch" },
+                        { "type": "fix", "release": "patch" },
+                        { "type": "build", "release": "patch" },
+                        { "type": "docs", "release": "patch" },
+                        { "type": "chore", "release": "patch" },
+                        { "type": "bench", "release": "patch" },
+                        { "type": "perf", "release": "patch" },
+                        { "type": "refactor", "release": "patch" },
+                        { "type": "test", "release": "patch" },
+                        { "type": "ci", "release": "patch" }
+                    ],
+                    "parserOpts": {
+                        "noteKeywords": [
+                            "BREAKING CHANGE",
+                            "BREAKING CHANGES",
+                            "BREAKING"
+                        ]
+                    }
+                }
+            ],
+            "@semantic-release/release-notes-generator",
+            [
+                "@semantic-release/exec",
+                {
+                    "prepareCmd": "bash ./ci/publish.sh ${nextRelease.version}"
+                }
+            ],
+            [
+                "@semantic-release/github"
+            ]
+        ]
+    },
+    "dependencies": {
+        "@semantic-release/exec": "^6.0.3"
+    }
+}


### PR DESCRIPTION
# Rationale for this change
The CLI and maybe other crates need to be published.
Depends on #97 and #99.