### PR TITLE
fix!: remove "sxt" from cli name & move rustflags to `.cargo/config.toml`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,7 @@
 [alias]
 f = "fmt --all -- --config imports_granularity=Crate,group_imports=One"
+
+[target.wasm32-unknown-unknown]
+rustflags = [
+  "-C", "opt-level=z",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,6 @@ repository = "https://github.com/spaceandtimelabs/sxt-proof-of-sql-sdk"
 version = "0.1.0"
 license-file = "LICENSE"
 
-[target.wasm32-unknown-unknown]
-rustflags = [
-  "-C", "opt-level=z",
-]
-
 [lib]
 crate-type = ["cdylib", "rlib"]
 
@@ -72,7 +67,7 @@ hyperkzg = ["proof-of-sql/hyperkzg_proof", "nova-snark"]
 wasm = ["subxt/web"]
 
 [[bin]]
-name = "sxt-proof-of-sql-cli"
+name = "proof-of-sql-cli"
 path = "src/main.rs"
 required-features = ["native"]
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -10,7 +10,7 @@ use clap::{Parser, Subcommand};
 #[command(
     name = "Proof of SQL Client",
     version = "1.0",
-    about = "Runs a SQL query and verifies the result using Dynamic Dory."
+    about = "Proof of SQL SDK Command Line Interface"
 )]
 pub struct ProofOfSqlSdkArgs {
     #[command(subcommand)]


### PR DESCRIPTION
# Rationale for this change
We don't want "sxt" in the CLI name. Also rustflags do not belong to `Cargo.toml`. Technically this change is breaking since we attempt to change the CLI binary name.