### PR TITLE
feat: use arrow pretty-print

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4.22"
 indexmap = "2.8.0"
 nova-snark = { version = "0.41.0", default-features = false, optional = true }
 parity-scale-codec = { version = "3.7.0", default-features = false, features = ["derive"] }
-proof-of-sql = { version = "=0.117.4", default-features = false }
+proof-of-sql = { version = "=0.117.4", default-features = false, features = ["arrow"] }
 proof-of-sql-planner = { version = "=0.117.4", default-features = false }
 prost = "0.12"
 prost-build = "0.12"

--- a/src/query_and_verify.rs
+++ b/src/query_and_verify.rs
@@ -1,5 +1,6 @@
 use crate::{base::CommitmentScheme, native::SxTClient};
 use clap::Args;
+use datafusion::arrow::{record_batch::RecordBatch, util::pretty::pretty_format_batches};
 use subxt::utils::H256;
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -96,11 +97,12 @@ pub async fn query_and_verify(
     let (client, commitment_scheme) = (&args).into();
 
     // Execute the query and verify the result
-    let result = client
+    let result: RecordBatch = client
         .query_and_verify(&args.query, args.block_hash, commitment_scheme)
-        .await?;
+        .await?
+        .try_into()?;
 
     // Print the result of the query
-    println!("Query result: {:?}", result);
+    println!("Query result:\n{}", pretty_format_batches(&[result])?);
     Ok(())
 }


### PR DESCRIPTION
# Rationale for this change
Debug for `OwnedTable` is not user-friendly. Hence we switch to Arrow to print our query results. 