### PR TITLE
fix!: fix `create_attestation_message` to line up with `sxt-node`

### DIFF
--- a/src/base/attestation.rs
+++ b/src/base/attestation.rs
@@ -220,11 +220,22 @@ fn slice_to_scalar(slice: &[u8]) -> Option<[u8; 32]> {
     slice.try_into().ok()
 }
 
-/// Create a message from a state root and block number
-pub fn create_attestation_message(state_root: impl AsRef<[u8]>, block_number: u32) -> Vec<u8> {
-    let mut msg = Vec::with_capacity(state_root.as_ref().len() + std::mem::size_of::<u32>());
+/// Creates an attestation message by concatenating the state root and block number.
+///
+/// # Arguments
+/// * `state_root` - A reference to the state root, typically a cryptographic hash.
+/// * `block_number` - The block number associated with this attestation.
+///
+/// # Returns
+/// A `Vec<u8>` containing the serialized attestation message.
+///
+pub fn create_attestation_message<BN: Into<u64>>(
+    state_root: impl AsRef<[u8]>,
+    block_number: BN,
+) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(state_root.as_ref().len() + core::mem::size_of::<u64>());
     msg.extend_from_slice(state_root.as_ref());
-    msg.extend_from_slice(&block_number.to_le_bytes());
+    msg.extend_from_slice(&block_number.into().to_be_bytes());
     msg
 }
 


### PR DESCRIPTION
# Rationale for this change
The `create_attestation_message` code we have in SDK does not line up with [sxt-node](https://github.com/spaceandtimefdn/sxt-node/blob/626f83e7e7dffc1ec1d929adf2515054c35b31c5/sxt-core/src/attestation.rs#L287-L304). Hence we need to fix it.

This is technically a breaking change since `create_attestation_message` was and is public and its functionality is clearly changing for people who use the SDK lib.