### PR TITLE
feat: add `get_proof_plan`

### DIFF
--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -11,7 +11,7 @@ mod substrate_query;
 pub use substrate_query::table_ref_to_table_id;
 
 mod proof_plan;
-pub use proof_plan::get_plan_from_accessor_and_query;
+pub use proof_plan::{get_plan_from_accessor_and_query, ProofPlanResponse};
 
 mod uppercase_accessor;
 pub use uppercase_accessor::uppercase_table_ref;

--- a/src/base/proof_plan.rs
+++ b/src/base/proof_plan.rs
@@ -4,7 +4,19 @@ use proof_of_sql::{base::database::SchemaAccessor, sql::proof_plans::DynProofPla
 use proof_of_sql_planner::{
     sql_to_proof_plans, statement_with_uppercase_identifiers, PlannerError,
 };
+use serde::{Deserialize, Serialize};
+use sp_core::Bytes;
 use sqlparser::ast::Statement;
+use subxt::utils::H256;
+
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProofPlanResponse {
+    /// The verifiable commitments.
+    pub proof_plan: Bytes,
+    /// The block hash that this query accessed storage with.
+    pub at: H256,
+}
 
 /// Retrieves a `DynProofPlan` given a query and the commitments for the relevant tables
 pub fn get_plan_from_accessor_and_query(

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -5,7 +5,7 @@ mod plan;
 pub use plan::produce_plan;
 
 mod rpc;
-pub use rpc::{fetch_attestation, fetch_verified_commitments};
+pub use rpc::{fetch_attestation, fetch_verified_commitments, get_proof_plan};
 
 mod client;
 pub use client::SxTClient;

--- a/src/native/rpc.rs
+++ b/src/native/rpc.rs
@@ -1,7 +1,7 @@
 use crate::base::{
     attestation::{Attestation, AttestationsResponse},
     verifiable_commitment::VerifiableCommitmentsResponse,
-    CommitmentScheme,
+    CommitmentScheme, ProofPlanResponse,
 };
 use jsonrpsee::{
     core::{client::ClientT, params::ArrayParams, rpc_params, ClientError},
@@ -66,6 +66,21 @@ pub async fn fetch_verified_commitments(
                 commitment_scheme.to_string(),
                 format!("{block_hash:#x}")
             ],
+        )
+        .await?;
+    Ok(response)
+}
+
+/// Fetch proof plan for a given query at a given block.
+pub async fn get_proof_plan(
+    client: &WsClient,
+    query: String,
+    block_hash: Option<H256>,
+) -> Result<ProofPlanResponse, ClientError> {
+    let response = client
+        .request::<ProofPlanResponse, ArrayParams>(
+            "commitments_v1_proofPlan",
+            rpc_params![query, block_hash.map(|h| format!("{h:#x}"))],
         )
         .await?;
     Ok(response)


### PR DESCRIPTION
# Rationale for this change
We need to fetch `DynProofPlan` from RPC (or elsewhere).