### PR TITLE
feat: add `network` to `SxTClient`

### DIFF
--- a/examples/count-ethereum-core/main.rs
+++ b/examples/count-ethereum-core/main.rs
@@ -6,7 +6,7 @@ use proof_of_sql::base::{
 };
 use std::{cmp::Ordering, env, fs::File, io::BufReader, path::Path, sync::Arc};
 use sxt_proof_of_sql_sdk::{
-    base::{CommitmentScheme, DynOwnedTable},
+    base::{zk_query_models::SxtNetwork, CommitmentScheme, DynOwnedTable},
     native::SxTClient,
 };
 use url::Url;
@@ -111,7 +111,16 @@ async fn main() {
         "hyper-kzg" => CommitmentScheme::HyperKzg,
         _ => panic!("Unsupported commitment scheme"),
     };
+    let network = match env::var("SXT_NETWORK")
+        .unwrap_or("mainnet".to_string())
+        .as_str()
+    {
+        "mainnet" => SxtNetwork::Mainnet,
+        "testnet" => SxtNetwork::Testnet,
+        _ => panic!("Unsupported network"),
+    };
     let client = Arc::new(SxTClient::new(
+        network,
         Url::parse(&env::var("ROOT_URL").unwrap_or("https://api.makeinfinite.dev".to_string()))
             .unwrap(),
         Url::parse(

--- a/src/base/zk_query_models.rs
+++ b/src/base/zk_query_models.rs
@@ -28,7 +28,7 @@ pub struct QueryPlanResponse {
 }
 
 /// The source of the underlying data
-#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone, Eq, ValueEnum)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone, Copy, Eq, ValueEnum)]
 #[serde(rename_all = "camelCase")]
 pub enum SxtNetwork {
     /// For now at least, this is the only value that is used

--- a/src/native/client.rs
+++ b/src/native/client.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::base::{
     plan_prover_query, prover::ProverResponse, uppercase_table_ref, verify_prover_response,
-    CommitmentEvaluationProofId, CommitmentScheme, DynOwnedTable,
+    zk_query_models::SxtNetwork, CommitmentEvaluationProofId, CommitmentScheme, DynOwnedTable,
 };
 use bumpalo::Bump;
 #[cfg(feature = "hyperkzg")]
@@ -22,6 +22,9 @@ use url::Url;
 /// Space and Time (SxT) client
 #[derive(Debug, Clone)]
 pub struct SxTClient {
+    /// SXT Network
+    pub network: SxtNetwork,
+
     /// Root URL for SXT services
     pub root_url: Url,
 
@@ -47,6 +50,7 @@ pub struct SxTClient {
 impl SxTClient {
     /// Create a new SxT client
     pub fn new(
+        network: SxtNetwork,
         root_url: Url,
         prover_url: Url,
         auth_root_url: Url,
@@ -55,6 +59,7 @@ impl SxTClient {
         verifier_setup: Option<String>,
     ) -> Self {
         Self {
+            network,
             root_url,
             prover_url,
             auth_root_url,

--- a/src/query_and_verify.rs
+++ b/src/query_and_verify.rs
@@ -1,4 +1,7 @@
-use crate::{base::CommitmentScheme, native::SxTClient};
+use crate::{
+    base::{zk_query_models::SxtNetwork, CommitmentScheme},
+    native::SxTClient,
+};
 use arrow_csv::WriterBuilder;
 use clap::Args;
 use datafusion::arrow::{
@@ -13,6 +16,18 @@ use url::Url;
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct QueryAndVerifySdkArgs {
+    /// SXT Network
+    ///
+    /// The SXT network to use.
+    /// Can be set via SXT_NETWORK environment variable.
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = SxtNetwork::Mainnet,
+        env = "SXT_NETWORK"
+    )]
+    pub network: SxtNetwork,
+
     /// Root URL for SXT services
     ///
     /// This URL is used as the base for other service URLs.
@@ -104,6 +119,7 @@ impl From<&QueryAndVerifySdkArgs> for (SxTClient, CommitmentScheme) {
     fn from(args: &QueryAndVerifySdkArgs) -> Self {
         (
             SxTClient::new(
+                args.network,
                 args.root_url.clone(),
                 args.prover_url.clone(),
                 args.auth_root_url.clone(),


### PR DESCRIPTION
# Rationale for this change
ZK Query API has a `network` param so we need to enable it before #143.